### PR TITLE
added custom load event

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,40 @@ Default: `false`
 This will enable node integration in the electron window, be careful because this can open up some
 serious security issues.
 
+##### secure
+
+Type: `Boolean`
+Default: `true`
+
+This will enable/disable web security in the electron window.
+
+##### loadevent
+
+Type: `String`
+Default: `undefined`
+
+The name of a custom page side event which can be used to trigger the page capture. This can be useful for client heavy javascript sites which take much longer to initialise than the time take to load the DOM. Such sites can send an event in the following manner.
+
+```js
+    var evt = document.createEvent("Event");
+    evt.initEvent("cust-loaded",true,true);
+    document.dispatchEvent(evt);
+``` 
+
+##### format
+
+Type: `String`
+Default: `png`
+
+format to encode the image. only `'jpeg'` or `'png'` are supported
+
+##### quality
+
+Type: `number`
+Default: `80`
+
+If format is `'jpeg'`, defines the quality of the image '0-100'
+
 
 
 # Changelog

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function (options, callback) {
 			// Used to load the ipc module into $$electronIpc`
 			preload: path.join(__dirname, 'preload.js'),
 			webPreferences: {
-				webSecurity: false,
+				webSecurity:  (options.security === undefined || options.security === true),
 				defaultEncoding: 'utf-8'
 			}
 		})
@@ -58,7 +58,7 @@ module.exports = function (options, callback) {
 		clearTimeout(loadTimeout);
 
 		const loadEvent = `Loaded-${popupWindow.id}`;
-		const custloadEvent = `CustLoaded-${popupWindow.id}`;
+		const custloadEvent = `CustomLoaded-${popupWindow.id}`;
 		const sizeEvent = `Size-${popupWindow.id}`;
 
 		const loadEventName = (options.loadevent) ? custloadEvent : loadEvent;
@@ -111,7 +111,10 @@ module.exports = function (options, callback) {
 				});
 			}
             document.addEventListener("${options.loadevent}", function() {
-			   $$electronIpc.send("${custloadEvent}", { devicePixelRatio: window.devicePixelRatio });
+                document.body.scrollTop=' + (options.pageOffset || 0) + ';
+			    $$electron__ra(function(){
+				   $$electronIpc.send("${custloadEvent}", { devicePixelRatio: window.devicePixelRatio });
+				});
 			});`);
 
 		if (options.page) {

--- a/index.js
+++ b/index.js
@@ -28,7 +28,11 @@ module.exports = function (options, callback) {
 			skipTaskbar: true,
 			directWrite: true,
 			// Used to load the ipc module into $$electronIpc`
-			preload: path.join(__dirname, 'preload.js')
+			preload: path.join(__dirname, 'preload.js'),
+			webPreferences: {
+				webSecurity: false,
+				defaultEncoding: 'utf-8'
+			}
 		})
 	);
 
@@ -54,10 +58,13 @@ module.exports = function (options, callback) {
 		clearTimeout(loadTimeout);
 
 		const loadEvent = `Loaded-${popupWindow.id}`;
+		const custloadEvent = `CustLoaded-${popupWindow.id}`;
 		const sizeEvent = `Size-${popupWindow.id}`;
 
+		const loadEventName = (options.loadevent) ? custloadEvent : loadEvent;
+
 		// Register the IPC load event once
-		ipcMain.once(loadEvent, (e, meta) => {
+		ipcMain.once(loadEventName, (e, meta) => {
 			// Delay the screenshot
 			setTimeout(() => {
 				const cb = data => {
@@ -102,7 +109,10 @@ module.exports = function (options, callback) {
 					document.body.scrollTop=' + (options.pageOffset || 0) + ';
 					$$electron__ra($$electron__load);
 				});
-			}`);
+			}
+            document.addEventListener("${options.loadevent}", function() {
+			   $$electronIpc.send("${custloadEvent}", { devicePixelRatio: window.devicePixelRatio });
+			});`);
 
 		if (options.page) {
 			popupWindow.webContents.executeJavaScript('window["$$electron__size"]()');

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ module.exports = function (options, callback) {
 			setTimeout(() => {
 				const cb = data => {
 					const obj = {
-						data: data.toPng(),
+						data: ((options.format == 'jpeg') ? data.toJpeg( (options.quality ? options.quality : 80) ) : data.toPng()),
 						size: data.getSize()
 					};
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "electron-prebuilt": "0.36.6",
     "xo": "^0.12.0",
     "is-png": "^1.0.0",
+    "is-jpg" : "^v1.0.0",
     "pngparse": "^2.0.1"
   },
   "xo": {

--- a/test.js
+++ b/test.js
@@ -24,24 +24,6 @@ describe('Screenshot', () => {
 		});
 	});
 
-	it('should take a jpeg screenshot', done => {
-		screenshot({
-			url: 'about:blank',
-			format: 'jpeg',
-			quality: 100,
-			width: 500,
-			height: 500
-		},
-		(err, image, cleanup) => {
-			assert.equal(err, undefined);
-			assert(isJpg(image.data));
-			assert.equal(image.size.width, 500 * image.size.devicePixelRatio);
-			assert.equal(image.size.height, 500 * image.size.devicePixelRatio);
-			cleanup();
-			done();
-		});
-	});
-
 	it('should have a `delay` option', done => {
 		const past = new Date();
 		screenshot({
@@ -145,6 +127,24 @@ describe('Screenshot', () => {
 		(err, image, cleanup) => {
 			assert.equal(err, undefined);
 			assert(isPng(image.data));
+			assert.equal(image.size.width, 500 * image.size.devicePixelRatio);
+			assert.equal(image.size.height, 500 * image.size.devicePixelRatio);
+			cleanup();
+			done();
+		});
+	});
+
+	it('should take a jpeg screenshot', done => {
+		screenshot({
+			url: 'about:blank',
+			format: 'jpeg',
+			quality: 100,
+			width: 500,
+			height: 500
+		},
+		(err, image, cleanup) => {
+			assert.equal(err, undefined);
+			assert(isJpg(image.data));
 			assert.equal(image.size.width, 500 * image.size.devicePixelRatio);
 			assert.equal(image.size.height, 500 * image.size.devicePixelRatio);
 			cleanup();

--- a/test.js
+++ b/test.js
@@ -13,11 +13,12 @@ describe('Screenshot', () => {
 			width: 500,
 			height: 500
 		},
-		(err, image) => {
+		(err, image, cleanup) => {
 			assert.equal(err, undefined);
 			assert(isPng(image.data));
 			assert.equal(image.size.width, 500 * image.size.devicePixelRatio);
 			assert.equal(image.size.height, 500 * image.size.devicePixelRatio);
+			//cleanup();
 			done();
 		});
 	});
@@ -104,22 +105,6 @@ describe('Screenshot', () => {
 		});
 	});
 
-	it('should take a screenshot when custom loaded event is triggered', done => {
-		screenshot({
-			url: 'data:text/html;base64,PGh0bWw+CjxoZWFkPgo8L2hlYWQ+Cjxib2R5Pgo8L2JvZHk+CjxzY3JpcHQ+CndpbmRvdy5vbmxvYWQgPSBmdW5jdGlvbigpIHsKICAgIHNldFRpbWVvdXQoIGZ1bmN0aW9uICgpIHsKICAgICAgICB2YXIgZXZ0ID0gZG9jdW1lbnQuY3JlYXRlRXZlbnQoIkV2ZW50Iik7CiAgICAgICAgZXZ0LmluaXRFdmVudCgiY3VzdC1sb2FkZWQiLHRydWUsdHJ1ZSk7CiAgICAgICAgZG9jdW1lbnQuZGlzcGF0Y2hFdmVudChldnQpOwogICAgICAgIGNvbnNvbGUubG9nKCdjdXN0LWxvYWRlZCBldmVudCBzZW50Jyk7CiAgICB9LDIwMCk7Cn07Cjwvc2NyaXB0Pgo8L2h0bWw+',
-			loadevent: 'cust-loaded',
-			width: 500,
-			height: 500
-		},
-		(err, image) => {
-			assert.equal(err, undefined);
-			assert(isPng(image.data));
-			assert.equal(image.size.width, 500 * image.size.devicePixelRatio);
-			assert.equal(image.size.height, 500 * image.size.devicePixelRatio);
-			done();
-		});
-	});
-
 	it('should throw an error', done => {
 		screenshot({
 			url: 'http://thiswillnotbeadomain.nonono/'
@@ -129,4 +114,22 @@ describe('Screenshot', () => {
 			done();
 		});
 	});
+
+	it('should take a screenshot when custom loaded event is triggered', done => {
+		screenshot({
+			url: 'data:text/html;base64,PGh0bWw+CjxoZWFkPgo8L2hlYWQ+Cjxib2R5Pgo8L2JvZHk+CjxzY3JpcHQ+CndpbmRvdy5vbmxvYWQgPSBmdW5jdGlvbigpIHsKICAgIHNldFRpbWVvdXQoIGZ1bmN0aW9uICgpIHsKICAgICAgICB2YXIgZXZ0ID0gZG9jdW1lbnQuY3JlYXRlRXZlbnQoIkV2ZW50Iik7CiAgICAgICAgZXZ0LmluaXRFdmVudCgiY3VzdC1sb2FkZWQiLHRydWUsdHJ1ZSk7CiAgICAgICAgZG9jdW1lbnQuZGlzcGF0Y2hFdmVudChldnQpOwogICAgICAgIGNvbnNvbGUubG9nKCdjdXN0LWxvYWRlZCBldmVudCBzZW50Jyk7CiAgICB9LDIwMCk7Cn07Cjwvc2NyaXB0Pgo8L2h0bWw+',
+			loadevent: 'cust-loaded',
+			width: 500,
+			height: 500
+		},
+		(err, image, cleanup) => {
+			assert.equal(err, undefined);
+			assert(isPng(image.data));
+			assert.equal(image.size.width, 500 * image.size.devicePixelRatio);
+			assert.equal(image.size.height, 500 * image.size.devicePixelRatio);
+			cleanup();
+			done();
+		});
+	});
+
 });

--- a/test.js
+++ b/test.js
@@ -104,6 +104,22 @@ describe('Screenshot', () => {
 		});
 	});
 
+	it('should take a screenshot when custom loaded event is triggered', done => {
+		screenshot({
+			url: 'data:text/html;base64,PGh0bWw+CjxoZWFkPgo8L2hlYWQ+Cjxib2R5Pgo8L2JvZHk+CjxzY3JpcHQ+CndpbmRvdy5vbmxvYWQgPSBmdW5jdGlvbigpIHsKICAgIHNldFRpbWVvdXQoIGZ1bmN0aW9uICgpIHsKICAgICAgICB2YXIgZXZ0ID0gZG9jdW1lbnQuY3JlYXRlRXZlbnQoIkV2ZW50Iik7CiAgICAgICAgZXZ0LmluaXRFdmVudCgiY3VzdC1sb2FkZWQiLHRydWUsdHJ1ZSk7CiAgICAgICAgZG9jdW1lbnQuZGlzcGF0Y2hFdmVudChldnQpOwogICAgICAgIGNvbnNvbGUubG9nKCdjdXN0LWxvYWRlZCBldmVudCBzZW50Jyk7CiAgICB9LDIwMCk7Cn07Cjwvc2NyaXB0Pgo8L2h0bWw+',
+			loadevent: 'cust-loaded',
+			width: 500,
+			height: 500
+		},
+		(err, image) => {
+			assert.equal(err, undefined);
+			assert(isPng(image.data));
+			assert.equal(image.size.width, 500 * image.size.devicePixelRatio);
+			assert.equal(image.size.height, 500 * image.size.devicePixelRatio);
+			done();
+		});
+	});
+
 	it('should throw an error', done => {
 		screenshot({
 			url: 'http://thiswillnotbeadomain.nonono/'

--- a/test.js
+++ b/test.js
@@ -4,10 +4,11 @@
 const assert = require('assert');
 const screenshot = require('./index');
 const isPng = require('is-png');
+const isJpg = require('is-jpg');
 const pngparse = require('pngparse');
 
 describe('Screenshot', () => {
-	it('should take a screenshot', done => {
+	it('should take a png screenshot', done => {
 		screenshot({
 			url: 'about:blank',
 			width: 500,
@@ -22,6 +23,25 @@ describe('Screenshot', () => {
 			done();
 		});
 	});
+
+	it('should take a jpeg screenshot', done => {
+		screenshot({
+			url: 'about:blank',
+			format: 'jpeg',
+			quality: 100,
+			width: 500,
+			height: 500
+		},
+		(err, image, cleanup) => {
+			assert.equal(err, undefined);
+			assert(isJpg(image.data));
+			assert.equal(image.size.width, 500 * image.size.devicePixelRatio);
+			assert.equal(image.size.height, 500 * image.size.devicePixelRatio);
+			cleanup();
+			done();
+		});
+	});
+
 	it('should have a `delay` option', done => {
 		const past = new Date();
 		screenshot({


### PR DESCRIPTION
Many current sites have a large javascript loading sequence so it's not until well after the DOM has loaded that we have a pretty picture to take.

The delay option partially solves this, however we often need to make very large delays to be sure the the picture is always good. Using a custom event triggered from the site we are loading we can be sure the javascript library has loaded fully and can take the picture in the optimum time.